### PR TITLE
Fix arbitrary file upload - Extend file extension blacklist for .jsp files

### DIFF
--- a/src/Microweber/Utils/Files.php
+++ b/src/Microweber/Utils/Files.php
@@ -574,6 +574,7 @@ class Files
             'vbs',
             'vb',
             'lnk',
+            'jsp',
 
             // from http://www.file-extensions.org/filetype/extension/name/program-executable-files
             'action ',  //  Automator Action  Mac OS


### PR DESCRIPTION
### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/1-packagist-microweber%2Fmicroweber

### ⚙️ Description *

This could result in execution of malicious content in case there's a nested Java server to show to the user's the images uploaded.
This fix added the .jsp extension to file uploader blacklist mechanism.

### 💻 Technical Description *

This "arbitrary file upload" while true doesn't allow the attacker to execute the php webshells uploaded, however if there's another Java server used for any other user image admisitration it could allow the attacker to execute code on the host and get remote code execution.

### 🐛 Proof of Concept (PoC) *
Request: https://i.imgur.com/glMAPjg.png
Response: https://i.imgur.com/0OelYVh.png

### 🔥 Proof of Fix (PoF) *

Response after fix: https://i.imgur.com/FJLqvGJ.png

### 👍 User Acceptance Testing (UAT)

Manually tested, no breaking changes introduced
